### PR TITLE
Change compiler directive -O2 to -Os

### DIFF
--- a/Compiler/COMMON/jo_engine_makefile
+++ b/Compiler/COMMON/jo_engine_makefile
@@ -229,7 +229,7 @@ CCFLAGS += -fkeep-inline-functions -W -Wall -Wshadow -Wbad-function-cast -Winlin
 -fno-common -ffast-math \
 --param max-inline-insns-single=50 -fms-extensions -std=gnu99 \
 -fmerge-all-constants -fno-ident -fno-unwind-tables -fno-asynchronous-unwind-tables \
--fomit-frame-pointer -fstrength-reduce -frerun-loop-opt -O2 -nodefaultlibs -nostdlib -fno-builtin \
+-fomit-frame-pointer -fstrength-reduce -frerun-loop-opt -Os -nodefaultlibs -nostdlib -fno-builtin \
 -m2 -c -I$(JO_ENGINE_SRC_DIR)
 
 ifneq ($(OS), Windows_NT)

--- a/jo_engine/math.c
+++ b/jo_engine/math.c
@@ -46,7 +46,9 @@
 
 // Thanks Ponut64 for optimized this method !
 // Johannes : demo - 2D storyboard doesn't work well because of overflow in computation I guess
-/*jo_fixed                jo_fixed_mult(jo_fixed x, jo_fixed y)
+// Ponut - -O2 and -Os have different rules for inline assembly. Using -Os will solve the issue.
+// O2 must have found register clobberings or out-of-order execution optimizations that were not so good.
+jo_fixed                jo_fixed_mult(jo_fixed x, jo_fixed y)
 {
 	register jo_fixed rtval;
 	asm(
@@ -59,36 +61,6 @@
 	:		"r1"						//CLOBBERS
 	);
 	return rtval;
-}*/
-
-jo_fixed                jo_fixed_mult(jo_fixed x, jo_fixed y)
-{
-	int                 a;
-    int                 c;
-    int                 ac;
-    int                 adcb;
-    int                 mulH;
-    unsigned int        b;
-    unsigned int        d;
-    unsigned int        bd;
-    unsigned int        tmp;
-    unsigned int        mulL;
-
-    a = JO_DIV_BY_65536(x);
-    c = JO_DIV_BY_65536(y);
-    b = (x & 0xFFFF);
-    d = (y & 0xFFFF);
-    ac = a * c;
-    adcb = a * d + c * b;
-    bd = b * d;
-    mulH = ac + JO_DIV_BY_65536(adcb);
-    tmp = JO_MULT_BY_65536(adcb);
-    mulL = bd + tmp;
-    if (mulL < bd)
-        ++mulH;
-    if (JO_DIV_BY_2147483648(mulH) == JO_DIV_BY_32768(mulH))
-        return (JO_MULT_BY_65536(mulH) | JO_DIV_BY_65536(mulL));
-    return (JO_FIXED_OVERFLOW);
 }
 
 /* Taylor series approximation */


### PR DESCRIPTION
Generally speaking, -O2 is less compatible than -Os.
In these newer compilers, you have the most trouble with the optimization options.
I know we like using them to speed up the software without any work.
It's really great.

But funnily enough, the old compiler could use -O3 and work in my project.
It would factually produce faster code. But the binary was too big to work with after awhile.

Between -O2 and -Os in the case right now, there is little or no difference.
This one is up to you. I cannot solve the problem with the function if the compiler changes the rules on me. Adding some pre-processor in the function to check or derive overflows is 100% undesirable and will cost you more than O2 or O3 can ever save on such fundamental functions.