### PR TITLE
jo_memset: Check for 0 len

### DIFF
--- a/jo_engine/tools.c
+++ b/jo_engine/tools.c
@@ -362,6 +362,9 @@ void                        jo_memset(const void * const restrict ptr, const int
     unsigned int            tail;
     unsigned int            x;
     unsigned char           xx;
+	
+    if(num == 0)
+        return;
 
     x = value & 0xff;
     xx = value & 0xff;


### PR DESCRIPTION
Avoid infinite loop when len is 0 in jo_memset. I was porting coded that called memset and relied on memset(..., ..., 0) being safe.

I hate GIT it's complaining about all the line endings. 