### PR TITLE
Replace JO_480p with JO_480i

### DIFF
--- a/Compiler/COMMON/jo_engine_makefile
+++ b/Compiler/COMMON/jo_engine_makefile
@@ -162,9 +162,9 @@ else
 	endif
 endif
 
-ifeq (${JO_480p},)
+ifeq (${JO_480i},)
 else
-	CCFLAGS += -DJO_480p
+	CCFLAGS += -DJO_480i
 endif
 
 ifeq (${JO_NTSC},)

--- a/jo_engine/jo/conf.h
+++ b/jo_engine/jo/conf.h
@@ -79,7 +79,7 @@
 */
 
 # if defined(JO_NTSC_VERSION)
-    # if defined(JO_480p)
+    # if defined(JO_480i)
         /** @brief Sega Saturn NTSC Screen resolution (internal use) */
         # define JO_TV_RES							(TV_704x480)
         /** @brief NTSC Screen width */
@@ -128,7 +128,7 @@
 
 #endif
 
-# if defined (JO_480p)
+# if defined (JO_480i)
     /** @brief VDP2 Background bitmap size */
     # define JO_VDP2_SIZE                       (BM_1024x512)
     /** @brief VDP2 Background bitmap width */


### PR DESCRIPTION
Replace all 4 instance of JO_480p with JO_480i as it is the more accurate definition. JO_480i mode still does not function. 