### PR TITLE
Backup: jo_backup_save_file_contents() length fix

### DIFF
--- a/jo_engine/backup.c
+++ b/jo_engine/backup.c
@@ -322,7 +322,7 @@ bool                jo_backup_file_exists(const jo_backup_device backup_device, 
     return (__jo_backup_devices[backup_device].status == 1);
 }
 
-bool                jo_backup_save_file_contents(const jo_backup_device backup_device, const char * const fname, const char * const comment, void *contents, unsigned short content_size)
+bool                jo_backup_save_file_contents(const jo_backup_device backup_device, const char * const fname, const char * const comment, void *contents, unsigned int content_size)
 {
     jo_backup_date  date;
     jo_backup_file  dir;

--- a/jo_engine/jo/backup.h
+++ b/jo_engine/jo/backup.h
@@ -106,7 +106,7 @@ bool                jo_backup_format_device(const jo_backup_device backup_device
  *  @param content_size Data size
  *  @return true if succeed
  */
-bool                jo_backup_save_file_contents(const jo_backup_device backup_device, const char * const fname, const char * const comment, void *contents, unsigned short content_size);
+bool                jo_backup_save_file_contents(const jo_backup_device backup_device, const char * const fname, const char * const comment, void *contents, unsigned int content_size);
 
 /** @brief Delete file on the backup device
  *  @param backup_device Backup device


### PR DESCRIPTION
Currently jo_backup_save_file_contents() takes the content length as an unsigned short for a maximum of 64k saves. Unfortunately saves appear to be as large as 256k. Changing the function parameter to unsigned int fixes the issue.