### PR TITLE
Increase Max backup files

### DIFF
--- a/jo_engine/jo/backup.h
+++ b/jo_engine/jo/backup.h
@@ -42,7 +42,7 @@
 # define JO_BACKUP_MAX_FILENAME_LENGTH      (12)
 
 /** @brief Max backup file in device */
-# define JO_BACKUP_MAX_FILE                 (32)
+# define JO_BACKUP_MAX_FILE                 (255)
 
 /** @brief Backup device type
   * @warning If you change these values, the program will crash


### PR DESCRIPTION
Users with more than 32 saves were reporting issues with Save Game Copier. This fix allows up to 255 files to be read.

The drawbacks is that is uses much more stack space. I don't know if that's reasonable or not. I also don't know what the maximum number of individual files is. 