### PR TITLE
Core: change to reboot and exit to multiplayer

### DIFF
--- a/jo_engine/jo/core.h
+++ b/jo_engine/jo/core.h
@@ -164,13 +164,23 @@ static  __jo_force_inline void      jo_core_tv_on(void)
     slTVOn();
 }
 
-/** @brief Restart the Saturn
+/** @brief Exit program and return to the Saturn multiplayer (CD player) screen
  *  @warning Works but I didn't found documentation about it
  *  @todo Investigate and give feedback to https://segaxtreme.net/threads/best-way-to-debug-saturn-bios.18644/
  */
+static  __jo_force_inline void jo_core_exit_to_multiplayer(void)
+{
+
+    (**(void(**)(void))0x600026C)();
+}
+
+/** @brief Restart the Saturn
+ *  @warning Doesn't work in Yabause
+ */
 static  __jo_force_inline void jo_core_restart_saturn(void)
 {
-    (**(void(**)(void))0x600026C)();
+    jo_smpc_begin_command();
+    jo_smpc_end_command(SystemReset);
 }
 
 /** @brief Set scroll screen order between them


### PR DESCRIPTION
Changed: jo_core_restart_saturn() to restart the Saturn. Before it exited to the Saturn multiplayer. Does not work in Yabause. 
Added: jo_core_exit_to_multiplayer() exits program to the Saturn multiplayer.

With this change jo_core_restart_saturn() fits it's description better. The functionality to exit to the multiplayer was retained as well but put in a different function.