### PR TITLE
Linux fixes

### DIFF
--- a/Compiler/COMMON/jo_engine_makefile
+++ b/Compiler/COMMON/jo_engine_makefile
@@ -265,10 +265,10 @@ LDFLAGS = -m2
 #ifeq (1,${JO_COMPILE_USING_SGL})
 	LDFLAGS += -L$(SGLLDR)
 #endif
-LDFLAGS +=-Xlinker --format=elf32-sh -Xlinker -T$(LDFILE) -Xlinker -Map \
+LDFLAGS +=-Xlinker -T$(LDFILE) -Xlinker -Map \
           -Xlinker $(MPFILE) -Xlinker -e -Xlinker ___Start -nostartfiles
 ifneq ($(OS), Windows_NT)
-LIBS += -L.$(COMPILER_DIR)/LINUX/sh-elf/sh-elf/lib/ -Wl,--format=elf32-sh -Wl,--relax -lgcc
+LIBS += -L.$(COMPILER_DIR)/LINUX/sh-elf/sh-elf/lib/ -Wl,--relax -lgcc
 endif
 DFLAGS =
 

--- a/Compiler/COMMON/jo_engine_makefile
+++ b/Compiler/COMMON/jo_engine_makefile
@@ -227,6 +227,7 @@ else
 	CC=$(COMPILER_DIR)/LINUX/bin/sh-none-elf-gcc-8.2.0
 	CONV=$(COMPILER_DIR)/LINUX/bin/sh-none-elf-objcopy
 	CUE_MAKER="$(COMPILER_DIR)/LINUX/Other Utilities/CueMaker"
+	CCFLAGS+="-I$(COMPILER_DIR)/WINDOWS/sh-elf/include"
 endif
 
 ASSETS_DIR=./cd
@@ -243,7 +244,7 @@ RM = rm -rf
 CMNDIR = $(COMPILER_DIR)/COMMON
 
 CCFLAGS += -fkeep-inline-functions -W -Wall -Wshadow -Wbad-function-cast -Winline -Wcomment \
--Winline -Wlong-long -Wsign-compare -Wextra -Wno-strict-aliasing \
+-Winline -Wsign-compare -Wextra -Wno-strict-aliasing \
 -fno-common -ffast-math \
 --param max-inline-insns-single=50 -fms-extensions -std=gnu99 \
 -fmerge-all-constants -fno-ident -fno-unwind-tables -fno-asynchronous-unwind-tables \

--- a/Compiler/COMMON/sgl.linker
+++ b/Compiler/COMMON/sgl.linker
@@ -1,4 +1,3 @@
-OUTPUT_FORMAT(coff-sh)
 SECTIONS {		
 	SLSTART 0x06004000 : {	
 		___Start = .;	


### PR DESCRIPTION
Hello! Here are some minor fixes relevant to Linux support:

- #include <stdint.h> was not available in the Linux toolchain, and
- `game.elf` was actually a COFF file; the patch ensures it's ELF.