### PR TITLE
Add new jo_fixed_cos func and correct tan division

### DIFF
--- a/jo_engine/jo/math.h
+++ b/jo_engine/jo/math.h
@@ -754,10 +754,7 @@ static  __jo_force_inline float	jo_sinf_mult(const float value, const int deg)
  *  @param rad Fixed angle in radian
  *  @return Cos(rad)
  */
-static  __jo_force_inline jo_fixed jo_fixed_cos(jo_fixed rad)
-{
-    return (jo_fixed_sin(rad + JO_FIXED_PI_DIV_2));
-}
+jo_fixed                            jo_fixed_cos(jo_fixed rad);
 
 /** @brief Fast cosinus computation
  *  @param deg Angle in degree
@@ -771,7 +768,7 @@ static  __jo_force_inline jo_fixed	jo_cos(const int deg)
 /** @brief Cosinus computation
  *  @param deg Angle in degree
  *  @return Cos(deg) using floating number (slow)
- *  @warning slower than jo_sin() because it use floating point
+ *  @warning slower than jo_cos() because it use floating point
  */
 static  __jo_force_inline float	jo_cosf(const int deg)
 {
@@ -781,7 +778,7 @@ static  __jo_force_inline float	jo_cosf(const int deg)
 /** @brief Cosinus computation
  *  @param rad Angle in radian
  *  @return Fixed Cos(rad)
- *  @warning slower than jo_sin() because it use floating point
+ *  @warning slower than jo_cos() because it use floating point
  */
 static  __jo_force_inline jo_fixed	jo_cos_rad(const float rad)
 {
@@ -791,7 +788,7 @@ static  __jo_force_inline jo_fixed	jo_cos_rad(const float rad)
 /** @brief Cosinus computation
  *  @param rad Angle in radian
  *  @return Cos(rad) using floating number (slow)
- *  @warning slower than jo_sin_rad() because it use floating point
+ *  @warning slower than jo_cos_rad() because it use floating point
  */
 static  __jo_force_inline float	jo_cos_radf(const float rad)
 {
@@ -834,7 +831,7 @@ static  __jo_force_inline float	jo_cosf_mult(const float value, const int deg)
  */
 static __jo_force_inline jo_fixed    jo_tan(const int deg)
 {
-    return (jo_sin(deg) / jo_cos(deg));
+    return jo_fixed_div(jo_sin(deg), jo_cos(deg));
 }
 
 /** @brief Tangent computation
@@ -854,7 +851,7 @@ static __jo_force_inline float    jo_tanf(const float deg)
  */
 static __jo_force_inline jo_fixed    jo_tan_rad(const float rad)
 {
-    return (jo_sin_rad(rad) / jo_cos_rad(rad));
+    return jo_fixed_div(jo_sin_rad(rad), jo_cos_rad(rad));
 }
 
 /** @brief Tangent computation

--- a/jo_engine/math.c
+++ b/jo_engine/math.c
@@ -145,7 +145,7 @@ jo_fixed	jo_fixed_div(jo_fixed dividend, jo_fixed divisor)
 }
 
 
-/* Taylor series approximation */
+/* Taylor series approximation for fixed sin */
 jo_fixed                jo_fixed_sin(jo_fixed rad)
 {
     jo_fixed            result;
@@ -167,6 +167,38 @@ jo_fixed                jo_fixed_sin(jo_fixed rad)
     result -= (rad / 39916800);
 
     return (result);
+}
+
+/* 
+** Taylor series approximation for fixed cos 
+** Code based on Austin Henley's cosine blog: https://austinhenley.com/blog/cosine.html
+*/
+jo_fixed                jo_fixed_cos(jo_fixed rad)
+{
+    int div = jo_fixed2int(jo_fixed_div(rad, JO_FIXED_PI));
+    rad = rad - jo_fixed_mult(toFIXED(div) , JO_FIXED_PI);
+    char sign = 1;
+    if (div % 2 != 0){
+        sign = -1;
+    }
+
+    jo_fixed x2 = jo_fixed_mult(rad, rad);
+    jo_fixed inter = jo_fixed_div(x2 , 131072);
+    jo_fixed result = toFIXED(1) - inter;
+
+    inter = jo_fixed_mult(inter, jo_fixed_div(x2 , 786432));
+    result += inter;
+
+    inter = jo_fixed_mult(inter, jo_fixed_div(x2 , 1966080));
+    result -= inter;
+
+    inter = jo_fixed_mult(inter, jo_fixed_div(x2 , 3670016));
+    result += inter;
+
+    inter = jo_fixed_mult(inter, jo_fixed_div(x2 , 5898240));
+    result -= inter;
+
+    return jo_fixed_mult(toFIXED(sign) , result);
 }
 
 /*


### PR DESCRIPTION
**Changelog:**

- Previous method of obtaining cos from sin(rad - pi/2) causes discrepancy between sin and cos values when used together. (At least the 3rd, 4th, and 5th DP were incorrect for cos!)
- Tan sees greater accuracy since it used cos and corrected use of fixed division.

**Description:**
Here is a few math calculations to prove new cos(45degree) function accuracy:
![image](https://user-images.githubusercontent.com/2172019/173664855-ec4b5494-0f48-49a8-b81e-2703953aed92.png)

You can compare sin/cos/tan values with this table at the 45 degrees mark: https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1011&context=mathclass

I noticed this cos issue as I am creating a right-angle turn movement along a grid. In this gif, you can see when I turn right (EAST), the grid starts trailing off the screen, and then the other gif is with the fix:

**Original cos():**
![old_cos](https://user-images.githubusercontent.com/2172019/173665853-5fa12e5d-02fc-4948-9779-7ce3cd25adcf.gif)

**Fixed cos():**
![new_cos](https://user-images.githubusercontent.com/2172019/173665882-11709a76-fa3b-44e5-94ee-22003539481e.gif)


Interesting, **sglCos** is showing an inaccuracy as well.. i'll leave that for someone else to look into!

