### PR TITLE
Quick fix for an issue where .bin ended up in the .cue on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 0.bin
 sl_coff.bin
+sl_coff.raw
 sl_coff.coff
 sl_coff.iso
 sl_coff.cue
 sl_coff.map
 game.bin
+game.raw
 game.coff
 game.elf
 game.iso

--- a/Compiler/COMMON/jo_engine_makefile
+++ b/Compiler/COMMON/jo_engine_makefile
@@ -275,7 +275,7 @@ endif
 DFLAGS =
 
 TARGET   = game.elf
-TARGET1  = $(TARGET:.elf=.bin)
+TARGET1  = $(TARGET:.elf=.raw)
 TARGET2  = $(TARGET:.elf=.iso)
 TARGET3  = $(TARGET:.elf=.cue)
 MPFILE   = $(TARGET:.elf=.map)

--- a/Samples/demo - 2D storyboard/clean.bat
+++ b/Samples/demo - 2D storyboard/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 2D storyboard/clean.sh
+++ b/Samples/demo - 2D storyboard/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D - programmatically/clean.bat
+++ b/Samples/demo - 3D - programmatically/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D - programmatically/clean.sh
+++ b/Samples/demo - 3D - programmatically/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D map/clean.bat
+++ b/Samples/demo - 3D map/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D map/clean.sh
+++ b/Samples/demo - 3D map/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D/clean.bat
+++ b/Samples/demo - 3D/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 3D/clean.sh
+++ b/Samples/demo - 3D/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 8bits tga/clean.bat
+++ b/Samples/demo - 8bits tga/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - 8bits tga/clean.sh
+++ b/Samples/demo - 8bits tga/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - advanced 3D/clean.bat
+++ b/Samples/demo - advanced 3D/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - advanced 3D/clean.sh
+++ b/Samples/demo - advanced 3D/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - audio/clean.bat
+++ b/Samples/demo - audio/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - audio/clean.sh
+++ b/Samples/demo - audio/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - audio/main.c
+++ b/Samples/demo - audio/main.c
@@ -47,9 +47,9 @@ void			    my_gamepad(void)
     {
         if (!is_cd_playing)
         {
-            /* The first two tracks in this demo are reserved so the first audio track is 3.
+            /* The first track in this demo is game data so the first audio track is 2.
                For more details you can open "game.cue" file with a notepad */
-            jo_audio_play_cd_track(3, 3, true);
+            jo_audio_play_cd_track(2, 2, true);
             is_cd_playing = true;
         }
         else

--- a/Samples/demo - background/clean.bat
+++ b/Samples/demo - background/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - background/clean.sh
+++ b/Samples/demo - background/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - backup/clean.bat
+++ b/Samples/demo - backup/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - backup/clean.sh
+++ b/Samples/demo - backup/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - bullet/clean.bat
+++ b/Samples/demo - bullet/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - bullet/clean.sh
+++ b/Samples/demo - bullet/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - debug console/clean.bat
+++ b/Samples/demo - debug console/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - debug console/clean.sh
+++ b/Samples/demo - debug console/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - everydaycute/clean.bat
+++ b/Samples/demo - everydaycute/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - everydaycute/clean.sh
+++ b/Samples/demo - everydaycute/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - filesystem/clean.bat
+++ b/Samples/demo - filesystem/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - filesystem/clean.sh
+++ b/Samples/demo - filesystem/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - gamepad/clean.bat
+++ b/Samples/demo - gamepad/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - gamepad/clean.sh
+++ b/Samples/demo - gamepad/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - gouraud shading/clean.bat
+++ b/Samples/demo - gouraud shading/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - gouraud shading/clean.sh
+++ b/Samples/demo - gouraud shading/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - hardcoded image/clean.bat
+++ b/Samples/demo - hardcoded image/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - hardcoded image/clean.sh
+++ b/Samples/demo - hardcoded image/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - homing laser/clean.bat
+++ b/Samples/demo - homing laser/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - homing laser/clean.sh
+++ b/Samples/demo - homing laser/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - line scroll/clean.bat
+++ b/Samples/demo - line scroll/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - line scroll/clean.sh
+++ b/Samples/demo - line scroll/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - map/clean.bat
+++ b/Samples/demo - map/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - map/clean.sh
+++ b/Samples/demo - map/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - mode7/clean.bat
+++ b/Samples/demo - mode7/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - mode7/clean.sh
+++ b/Samples/demo - mode7/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - multitap/clean.bat
+++ b/Samples/demo - multitap/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - multitap/clean.sh
+++ b/Samples/demo - multitap/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - nbg2 font/clean.bat
+++ b/Samples/demo - nbg2 font/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - nbg2 font/clean.sh
+++ b/Samples/demo - nbg2 font/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - paint/clean.bat
+++ b/Samples/demo - paint/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - paint/clean.sh
+++ b/Samples/demo - paint/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - printf/clean.bat
+++ b/Samples/demo - printf/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - printf/clean.sh
+++ b/Samples/demo - printf/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - shooter/clean.bat
+++ b/Samples/demo - shooter/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - shooter/clean.sh
+++ b/Samples/demo - shooter/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - simple water effect/clean.bat
+++ b/Samples/demo - simple water effect/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - simple water effect/clean.sh
+++ b/Samples/demo - simple water effect/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - software rendering/clean.bat
+++ b/Samples/demo - software rendering/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - software rendering/clean.sh
+++ b/Samples/demo - software rendering/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - sonic/clean.bat
+++ b/Samples/demo - sonic/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - sonic/clean.sh
+++ b/Samples/demo - sonic/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - sprite animation/clean.bat
+++ b/Samples/demo - sprite animation/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - sprite animation/clean.sh
+++ b/Samples/demo - sprite animation/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - tileset/clean.bat
+++ b/Samples/demo - tileset/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - tileset/clean.sh
+++ b/Samples/demo - tileset/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - vdp2 plane/clean.bat
+++ b/Samples/demo - vdp2 plane/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - vdp2 plane/clean.sh
+++ b/Samples/demo - vdp2 plane/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - video/clean.bat
+++ b/Samples/demo - video/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - video/clean.sh
+++ b/Samples/demo - video/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - visual novel/clean.bat
+++ b/Samples/demo - visual novel/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo - visual novel/clean.sh
+++ b/Samples/demo - visual novel/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo1/clean.bat
+++ b/Samples/demo1/clean.bat
@@ -7,6 +7,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f %JO_ENGINE_SRC_DIR%/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map

--- a/Samples/demo1/clean.sh
+++ b/Samples/demo1/clean.sh
@@ -3,6 +3,7 @@ rm -f ./cd/0.bin
 rm -f *.o
 rm -f ../../jo_engine/*.o
 rm -f ./*.bin
+rm -f ./*.raw
 rm -f ./*.coff
 rm -f ./*.elf
 rm -f ./*.map


### PR DESCRIPTION
Fixed an issue where .bin generated at compile ended up included in .cue causing audiotracks to be shifted by 1 and issues when converting image to single bincue or on some ODEs

This issue mainly affected windows, but the audio sample did not work on linux because of this either, as on linux the .bin was never included inside .cue, thus making audio tracks be with different id's