### PR TITLE
Fixes a bad pointer bug when clearing all sprites.

### DIFF
--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -131,13 +131,15 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
     return (__jo_sprite_anim_id);
 }
 
-void        jo_clear_all_sprite_anim(void)
+void jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;
-    jo_core_remove_callback(__jo_sprite_anim_callback_event_id);
-    JO_ZERO(__jo_sprite_anim_callback_event_id);
+    if (__jo_sprite_anim_callback_event_id > 0)  // Avoid calling with an invalid value.
+    {
+        jo_core_remove_callback(__jo_sprite_anim_callback_event_id);
+        __jo_sprite_anim_callback_event_id = 0; // Prevents reuse of an invalid value.
+    }
 }
-
 /*
 ** END OF FILE
 */

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -131,13 +131,13 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
     return (__jo_sprite_anim_id);
 }
 
-void jo_clear_all_sprite_anim(void)
+void    jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;
     if (__jo_sprite_anim_callback_event_id > 0)  // Avoid calling with an invalid value.
     {
         jo_core_remove_callback(__jo_sprite_anim_callback_event_id);
-        __jo_sprite_anim_callback_event_id = 0; // Prevents reuse of an invalid value.
+        JO_ZERO(__jo_sprite_anim_callback_event_id); // Prevents reuse of an invalid value.
     }
 }
 /*


### PR DESCRIPTION
When calling the `jo_clear_all_sprite_anim` function, a bad pointer error was being generated. However, not using this function caused a memory overflow, as it exceeded the animation creation limits.  

With this fix, the function is corrected, properly clearing animations from memory without causing a bad pointer error.