### PR TITLE
Fixing memory issue with sprite_animator.

### DIFF
--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -42,7 +42,7 @@
 
 jo_sprite_anim		__jo_sprite_anim_tab[JO_MAX_SPRITE_ANIM];
 static int			__jo_sprite_anim_id = -1;
-static char			__jo_sprite_anim_callback_event_id = 0;
+static int			__jo_sprite_anim_callback_event_id = 0;
 
 static void			__jo_internal_frame_animator(void)
 {
@@ -134,6 +134,8 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
 void    jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;
+    jo_memset(__jo_sprite_anim_tab, 0, sizeof(__jo_sprite_anim_tab));
+
     if (__jo_sprite_anim_callback_event_id > 0)  // Avoid calling with an invalid value.
     {
         jo_core_remove_callback(__jo_sprite_anim_callback_event_id);


### PR DESCRIPTION
I was still experiencing some memory issues when clearing animations. I made this fix and tested it extensively on real hardware. The issue was resolved for me.