### PR TITLE
Audio channel protection

### DIFF
--- a/jo_engine/audio.c
+++ b/jo_engine/audio.c
@@ -114,6 +114,29 @@ void		        jo_audio_init(void)
 #endif
 }
 
+bool                jo_audio_is_channel_playing(const unsigned char channel)
+{
+#ifdef JO_DEBUG
+    if (channel >= JO_SOUND_MAX_CHANNEL)
+    {
+        jo_core_error("channel (%d) is too high (max=%d)", channel, JO_SOUND_MAX_CHANNEL - 1);
+        return false;
+    }
+#endif
+
+    // Proteção redundante em builds release
+    if (channel >= JO_SOUND_MAX_CHANNEL)
+    {
+        return false;
+    }
+
+    // Evita qualquer dependência de comportamento inesperado de slPCMStat
+    const unsigned char status = slPCMStat(channel);
+
+    // Retorna se o bit 0 está setado
+    return (status & 0x01u) != 0;
+}
+
 void	            jo_audio_play_sound_on_channel(jo_sound * const sound, const unsigned char channel)
 {
 #ifdef JO_DEBUG

--- a/jo_engine/jo/audio.h
+++ b/jo_engine/jo/audio.h
@@ -81,6 +81,12 @@ void	jo_audio_set_volume(const unsigned char vol);
  */
 void	jo_audio_stop_cd(void);
 
+ /** @brief Checks whether a given audio channel is currently playing a sound
+  *  @param channel Channel to check (0 to JO_SOUND_MAX_CHANNEL - 1)
+  *  @return true if the channel is playing, false otherwise
+  */
+bool    jo_audio_is_channel_playing(const unsigned char channel);
+
 /** @brief Play a sound on a specific channel
  *  @param sound Sound definition
  *  @param channel Channel (0 to 6)

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -42,7 +42,7 @@
 
 jo_sprite_anim		__jo_sprite_anim_tab[JO_MAX_SPRITE_ANIM];
 static int			__jo_sprite_anim_id = -1;
-static char         __jo_sprite_anim_callback_event_id = 0;
+static char			__jo_sprite_anim_callback_event_id = 0;
 
 static void			__jo_internal_frame_animator(void)
 {

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -42,7 +42,7 @@
 
 jo_sprite_anim		__jo_sprite_anim_tab[JO_MAX_SPRITE_ANIM];
 static int			__jo_sprite_anim_id = -1;
-static char			__jo_sprite_anim_callback_event_id = 0;
+static int			__jo_sprite_anim_callback_event_id = 0;
 
 static void			__jo_internal_frame_animator(void)
 {
@@ -134,6 +134,8 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
 void    jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;
+    jo_memset(__jo_sprite_anim_tab, 0, sizeof(__jo_sprite_anim_tab));
+
     if (__jo_sprite_anim_callback_event_id > 0)  // Avoid calling with an invalid value.
     {
         jo_core_remove_callback(__jo_sprite_anim_callback_event_id);

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -42,7 +42,7 @@
 
 jo_sprite_anim		__jo_sprite_anim_tab[JO_MAX_SPRITE_ANIM];
 static int			__jo_sprite_anim_id = -1;
-static int			__jo_sprite_anim_callback_event_id = 0;
+static char         __jo_sprite_anim_callback_event_id = 0;
 
 static void			__jo_internal_frame_animator(void)
 {

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -134,8 +134,6 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
 void    jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;
-    jo_memset(__jo_sprite_anim_tab, 0, sizeof(__jo_sprite_anim_tab));
-
     if (__jo_sprite_anim_callback_event_id > 0)  // Avoid calling with an invalid value.
     {
         jo_core_remove_callback(__jo_sprite_anim_callback_event_id);


### PR DESCRIPTION
I created the jo_audio_is_channel_playing function because, in my project, I have a PCM sound that plays inside a loop. When using jo_audio_play_sound, I noticed that sometimes an invalid channel was triggered, resulting in a blue screen. Similarly, when calling jo_audio_play_sound_on_channel, I also encountered crashes when too many requests were made in a short time.
The solution was to check whether a sound is still playing on a given channel before attempting to play another sound on the same channel.

This fix was extremely helpful in my project, and I hope it can be useful to others as well.