### PR TITLE
Add function to remove a specific sprite animation by ID

### DIFF
--- a/jo_engine/jo/sprite_animator.h
+++ b/jo_engine/jo/sprite_animator.h
@@ -190,6 +190,11 @@ int			jo_replace_sprite_anim(const int at, const unsigned short sprite_id, const
  */
 int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short frame_count, const unsigned char frame_rate);
 
+/** @brief Remove a specific animation by ID
+ *  @param anim_id Id returned by jo_create_sprite_anim()
+ */
+void        jo_remove_sprite_anim(const int anim_id);
+
 /** @brief Clear all sprite animation
  */
 void        jo_clear_all_sprite_anim(void);

--- a/jo_engine/sprite_animator.c
+++ b/jo_engine/sprite_animator.c
@@ -131,6 +131,29 @@ int			jo_create_sprite_anim(const unsigned short sprite_id, const unsigned short
     return (__jo_sprite_anim_id);
 }
 
+void jo_remove_sprite_anim(const int anim_id)
+{
+    if (anim_id < 0 || anim_id > __jo_sprite_anim_id)
+        return;
+
+    jo_memset(&__jo_sprite_anim_tab[anim_id], 0, sizeof(jo_sprite_anim));
+
+    if (anim_id == __jo_sprite_anim_id)
+    {
+        while (__jo_sprite_anim_id >= 0 &&
+               __jo_sprite_anim_tab[__jo_sprite_anim_id].frame_count == 0)
+        {
+            --__jo_sprite_anim_id;
+        }
+
+        if (__jo_sprite_anim_id < 0 && __jo_sprite_anim_callback_event_id > 0)
+        {
+            jo_core_remove_callback(__jo_sprite_anim_callback_event_id);
+            JO_ZERO(__jo_sprite_anim_callback_event_id);
+        }
+    }
+}
+
 void    jo_clear_all_sprite_anim(void)
 {
     __jo_sprite_anim_id = -1;


### PR DESCRIPTION
In my game, I manage a large list of enemies stored in an array. As enemies enter and leave the screen, I create and remove their animations dynamically.

This new function allows me to pass the animation ID as a parameter and remove that specific animation from memory as needed. This helps keep the number of active animations in memory low and under control, optimizing resource usage.